### PR TITLE
Add RH7 universal base Docker image to CI/CD

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,8 +71,8 @@ jobs:
             -e CCACHE_MAXSIZE=400M \
             pirateteam/build \
             ninja -j 2 install-distribution
-          cp -r `pwd`/dist `pwd`/images/llvm-ubuntu/
-          cp -r `pwd`/dist `pwd`/images/llvm-rh7/
+          cp -r `pwd`/dist `pwd`/images/llvm-ubuntu/pirate-llvm
+          cp -r `pwd`/dist `pwd`/images/llvm-rh7/pirate-llvm
 #      - name: Run tests
 #        run: |
 #          docker run -i \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -95,8 +95,11 @@ jobs:
           path: images/llvm-ubuntu/pirate-llvm
       - name: Make pirateteam/llvm-ubuntu docker image
         run: docker build -t pirateteam/llvm-ubuntu images/llvm-ubuntu
+      - name: Make pirateteam/llvm-rh7 docker image
+        run: docker build -t pirateteam/llvm-rh7 images/llvm-rh7
       - name: Post docker images
         run: |
           echo ${{ secrets.docker_password }} | docker login -u gapspirateteam --password-stdin
           docker push pirateteam/llvm-ubuntu
+          docker push pirateteam/llvm-rh7
         if: github.ref == 'refs/heads/master'

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -63,7 +63,7 @@ jobs:
             --memory=16G \
             --mount type=bind,src=`pwd`/build,dst=/root/build  \
             --mount type=bind,src=`pwd`/cache,dst=/root/cache \
-            --mount type=bind,src=`pwd`/images/llvm-ubuntu,dst=/root/dist \
+            --mount type=bind,src=`pwd`/dist,dst=/root/dist \
             --mount type=bind,src=`pwd`,dst=/root/pirate-llvm,ro \
             -w /root/build \
             -e CCACHE_DIR=/root/cache/ccache \
@@ -71,6 +71,8 @@ jobs:
             -e CCACHE_MAXSIZE=400M \
             pirateteam/build \
             ninja -j 2 install-distribution
+          cp -r `pwd`/dist `pwd`/images/llvm-ubuntu/
+          cp -r `pwd`/dist `pwd`/images/llvm-rh7/
 #      - name: Run tests
 #        run: |
 #          docker run -i \

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -71,8 +71,8 @@ jobs:
             -e CCACHE_MAXSIZE=400M \
             pirateteam/build \
             ninja -j 2 install-distribution
-          cp -r `pwd`/dist `pwd`/images/llvm-ubuntu/pirate-llvm
-          cp -r `pwd`/dist `pwd`/images/llvm-rh7/pirate-llvm
+          cp -r `pwd`/dist/pirate-llvm `pwd`/images/llvm-ubuntu/pirate-llvm
+          cp -r `pwd`/dist/pirate-llvm `pwd`/images/llvm-rh7/pirate-llvm
 #      - name: Run tests
 #        run: |
 #          docker run -i \

--- a/images/llvm-rh7/.gitignore
+++ b/images/llvm-rh7/.gitignore
@@ -1,0 +1,1 @@
+pirate-llvm

--- a/images/llvm-rh7/Dockerfile
+++ b/images/llvm-rh7/Dockerfile
@@ -1,0 +1,23 @@
+FROM registry.access.redhat.com/ubi7/ubi
+
+RUN yum -y install \
+  libstdc++ libstdc++-devel libedit make binutils bzip2 gcc
+
+# valgrind is not in the repo and doesn't offer prebuilt binaries, so do it from source
+RUN curl -L https://sourceware.org/pub/valgrind/valgrind-3.15.0.tar.bz2 | tar xj \
+  && cd valgrind-3.15.0 \
+  && ./configure \
+  && make \
+  && make install
+
+# Get prebuilt binary cmake
+RUN curl -L https://github.com/Kitware/CMake/releases/download/v3.16.5/cmake-3.16.5-Linux-x86_64.tar.gz | tar zxv
+RUN ln -s /root/cmake-3.16.5-Linux-x86_64/bin/cmake /usr/local/bin/cmake
+
+COPY dist /usr/local
+RUN cd /usr/local/bin \
+ && ln -s clang cc \
+ && ln -s clang++ c++ \
+ && ln -s lld ld
+
+WORKDIR /root

--- a/images/llvm-rh7/Dockerfile
+++ b/images/llvm-rh7/Dockerfile
@@ -14,7 +14,7 @@ RUN curl -L https://sourceware.org/pub/valgrind/valgrind-3.15.0.tar.bz2 | tar xj
 RUN curl -L https://github.com/Kitware/CMake/releases/download/v3.16.5/cmake-3.16.5-Linux-x86_64.tar.gz | tar zxv
 RUN ln -s /root/cmake-3.16.5-Linux-x86_64/bin/cmake /usr/local/bin/cmake
 
-COPY dist /usr/local
+COPY pirate-llvm /usr/local
 RUN cd /usr/local/bin \
  && ln -s clang cc \
  && ln -s clang++ c++ \

--- a/images/llvm-rh7/Dockerfile
+++ b/images/llvm-rh7/Dockerfile
@@ -4,15 +4,15 @@ RUN yum -y install \
   libstdc++ libstdc++-devel libedit make binutils bzip2 gcc
 
 # valgrind is not in the repo and doesn't offer prebuilt binaries, so do it from source
-RUN curl -L https://sourceware.org/pub/valgrind/valgrind-3.15.0.tar.bz2 | tar xj \
-  && cd valgrind-3.15.0 \
-  && ./configure \
-  && make \
-  && make install
+# RUN curl -L https://sourceware.org/pub/valgrind/valgrind-3.15.0.tar.bz2 | tar xj \
+#   && cd valgrind-3.15.0 \
+#   && ./configure \
+#   && make \
+#   && make install
 
 # Get prebuilt binary cmake
-RUN curl -L https://github.com/Kitware/CMake/releases/download/v3.16.5/cmake-3.16.5-Linux-x86_64.tar.gz | tar zxv
-RUN ln -s /root/cmake-3.16.5-Linux-x86_64/bin/cmake /usr/local/bin/cmake
+RUN curl -L https://github.com/Kitware/CMake/releases/download/v3.16.5/cmake-3.16.5-Linux-x86_64.tar.gz | tar zxv \
+  && ln -s /root/cmake-3.16.5-Linux-x86_64/bin/cmake /usr/local/bin/cmake
 
 COPY pirate-llvm /usr/local
 RUN cd /usr/local/bin \

--- a/images/llvm-ubuntu/Dockerfile
+++ b/images/llvm-ubuntu/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update \
  && apt-get install --no-install-recommends -y libstdc++-7-dev cmake libedit2 make binutils valgrind \
  && rm -rf /var/lib/apt/lists/*
 
-COPY dist /usr/local
+COPY pirate-llvm /usr/local
 RUN cd /usr/local/bin \
  && ln -s clang cc \
  && ln -s clang++ c++ \

--- a/images/llvm-ubuntu/Dockerfile
+++ b/images/llvm-ubuntu/Dockerfile
@@ -12,7 +12,7 @@ RUN apt-get update \
  && apt-get install --no-install-recommends -y libstdc++-7-dev cmake libedit2 make binutils valgrind \
  && rm -rf /var/lib/apt/lists/*
 
-COPY pirate-llvm /usr/local
+COPY dist /usr/local
 RUN cd /usr/local/bin \
  && ln -s clang cc \
  && ln -s clang++ c++ \


### PR DESCRIPTION
This modifies the Github actions to create both Ubuntu (which we already had) and RH7 UBI Docker images with the compiled pirate-llvm tools.